### PR TITLE
chore: Add initial functionality to send recipe data to web app

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "scripts": {
     "build": "ts-node scripts/generate-manifest.ts && webpack --mode production",
-    "clean": "rm -rf build/*",
+    "clean": "rm -rf dist/*",
     "lint": "eslint .",
     "lint:ci": "eslint . --quiet",
     "prettier": "prettier . --write",

--- a/src/chrome-helpers.ts
+++ b/src/chrome-helpers.ts
@@ -1,3 +1,5 @@
+import { Message } from "~/messages/types";
+
 export const getCurrentTab = async () => {
   const [currentTab] = await chrome.tabs.query({
     active: true,
@@ -6,6 +8,17 @@ export const getCurrentTab = async () => {
 
   return currentTab;
 };
+
+export const createEmptyTab = () => chrome.tabs.create({ active: false });
+
+export const setTabUrl = (tabId: number, url: string) =>
+  chrome.tabs.update(tabId, {
+    active: true,
+    url,
+  });
+
+export const sendMessageToBackground = (message: Message) =>
+  chrome.runtime.sendMessage(message);
 
 export const getLocalStorage = async (key: string) => {
   const data = await chrome.storage.local.get(key);

--- a/src/config.ts
+++ b/src/config.ts
@@ -11,6 +11,7 @@ type Config = {
   VERSION: string;
   WEB_APP: {
     BROWSER_EXTENSION_PATH: string;
+    IMPORT_RECIPE_PATH: string;
     ORIGIN: string;
     SETTINGS_PATH: string;
   };
@@ -26,6 +27,7 @@ const configDecoder: Decoder<Config> = exact({
   VERSION: string,
   WEB_APP: exact({
     BROWSER_EXTENSION_PATH: string,
+    IMPORT_RECIPE_PATH: string,
     ORIGIN: string,
     SETTINGS_PATH: string,
   }),
@@ -43,6 +45,7 @@ const config = {
   VERSION: packageJson.version,
   WEB_APP: {
     BROWSER_EXTENSION_PATH: "/browser-extension",
+    IMPORT_RECIPE_PATH: "/import-recipe",
     ORIGIN: IS_PRODUCTION
       ? "https://tinyrecipebox.com"
       : "http://localhost:3000",

--- a/src/messages/decoders.ts
+++ b/src/messages/decoders.ts
@@ -14,7 +14,7 @@ const pingMessageDecoder: Decoder<PingMessage> = exact({
   }),
 });
 
-const recipeImporterReadyMessageDecoder: Decoder<RecipeImporterReadyMessage> =
+export const recipeImporterReadyMessageDecoder: Decoder<RecipeImporterReadyMessage> =
   exact({
     sender: constant("web-app"),
     type: constant("RECIPE_IMPORTER_READY"),

--- a/src/messages/decoders.ts
+++ b/src/messages/decoders.ts
@@ -1,5 +1,10 @@
-import { Decoder, constant, exact, uuidv4 } from "decoders";
-import { PingMessage, ReceivableServiceWorkerMessage } from "~/messages/types";
+import { Decoder, constant, either, exact, uuidv4 } from "decoders";
+import {
+  PingMessage,
+  ReceivableServiceWorkerMessage,
+  RecipeImporterReadyMessage,
+  SendRecipeDataMessage,
+} from "~/messages/types";
 
 const pingMessageDecoder: Decoder<PingMessage> = exact({
   sender: constant("web-app"),
@@ -9,5 +14,20 @@ const pingMessageDecoder: Decoder<PingMessage> = exact({
   }),
 });
 
+const recipeImporterReadyMessageDecoder: Decoder<RecipeImporterReadyMessage> =
+  exact({
+    sender: constant("web-app"),
+    type: constant("RECIPE_IMPORTER_READY"),
+  });
+
+const sendRecipeDataMessageDecoder: Decoder<SendRecipeDataMessage> = exact({
+  sender: constant("popup"),
+  type: constant("SEND_RECIPE_DATA"),
+});
+
 export const receivableServiceWorkerMessageDecoder: Decoder<ReceivableServiceWorkerMessage> =
-  pingMessageDecoder;
+  either(
+    pingMessageDecoder,
+    recipeImporterReadyMessageDecoder,
+    sendRecipeDataMessageDecoder,
+  );

--- a/src/messages/types.ts
+++ b/src/messages/types.ts
@@ -15,6 +15,7 @@ export type PingMessage = BaseMessage & {
   payload: {
     userId: string;
   };
+  sender: "web-app";
   type: "PING";
 };
 

--- a/src/messages/types.ts
+++ b/src/messages/types.ts
@@ -18,6 +18,28 @@ export type PingMessage = BaseMessage & {
   type: "PING";
 };
 
-export type Message = PingMessage;
+export type RecipeImporterReadyMessage = BaseMessage & {
+  sender: "web-app";
+  type: "RECIPE_IMPORTER_READY";
+};
 
-export type ReceivableServiceWorkerMessage = PingMessage;
+export type SendRecipeDataMessage = BaseMessage & {
+  sender: "popup";
+  type: "SEND_RECIPE_DATA";
+};
+
+export type RecipeDataMessage = BaseMessage & {
+  sender: "service-worker";
+  type: "RECIPE_DATA";
+};
+
+export type Message =
+  | PingMessage
+  | RecipeDataMessage
+  | RecipeImporterReadyMessage
+  | SendRecipeDataMessage;
+
+export type ReceivableServiceWorkerMessage =
+  | PingMessage
+  | RecipeImporterReadyMessage
+  | SendRecipeDataMessage;

--- a/src/popup/components/App/index.tsx
+++ b/src/popup/components/App/index.tsx
@@ -8,22 +8,26 @@ import { AppContainer, Card, ClipRecipeButton, Text, TopRow } from "./styled";
 const App = () => {
   const { data: userId, isPending } = useGetMe();
 
+  const isRequiresSync = userId === undefined;
+
   return (
     <AppContainer>
       <TopRow>
         <IconNav />
-        <ClipRecipeButton
-          onClick={() => {
-            sendMessageToBackground({
-              sender: "popup",
-              type: "SEND_RECIPE_DATA",
-            });
-          }}
-        >
-          Clip recipe
-        </ClipRecipeButton>
+        {!isRequiresSync ? (
+          <ClipRecipeButton
+            onClick={() => {
+              sendMessageToBackground({
+                sender: "popup",
+                type: "SEND_RECIPE_DATA",
+              });
+            }}
+          >
+            Clip recipe
+          </ClipRecipeButton>
+        ) : null}
       </TopRow>
-      {isPending ? null : userId === undefined ? (
+      {isPending ? null : isRequiresSync ? (
         <Card>
           <Text>
             Finish setting up this extension by syncing with the web app.

--- a/src/popup/components/App/index.tsx
+++ b/src/popup/components/App/index.tsx
@@ -3,8 +3,7 @@ import config from "~/config";
 import useGetMe from "~/hooks/useGetUserId";
 import IconNav from "~/popup/components/IconNav";
 import LinkPrimaryButton from "~/ui-shared/components/LinkPrimaryButton";
-import PrimaryButton from "~/ui-shared/components/PrimaryButton";
-import { AppContainer, Card, Text, TopRow } from "./styled";
+import { AppContainer, Card, ClipRecipeButton, Text, TopRow } from "./styled";
 
 const App = () => {
   const { data: userId, isPending } = useGetMe();
@@ -13,7 +12,7 @@ const App = () => {
     <AppContainer>
       <TopRow>
         <IconNav />
-        <PrimaryButton
+        <ClipRecipeButton
           onClick={() => {
             sendMessageToBackground({
               sender: "popup",
@@ -21,8 +20,8 @@ const App = () => {
             });
           }}
         >
-          Test
-        </PrimaryButton>
+          Clip recipe
+        </ClipRecipeButton>
       </TopRow>
       {isPending ? null : userId === undefined ? (
         <Card>

--- a/src/popup/components/App/index.tsx
+++ b/src/popup/components/App/index.tsx
@@ -10,11 +10,11 @@ const App = () => {
 
   const isRequiresSync = userId === undefined;
 
+  // TODO: Add conditions to show/enable the clip recipe button once valid website/recipe detection is implemented.
   return (
     <AppContainer>
       <TopRow>
         <IconNav />
-        {/* TODO: Add conditions to show/enable this button once valid website/recipe detection is implemented. */}
         {!isRequiresSync ? (
           <ClipRecipeButton
             onClick={() => {

--- a/src/popup/components/App/index.tsx
+++ b/src/popup/components/App/index.tsx
@@ -14,6 +14,7 @@ const App = () => {
     <AppContainer>
       <TopRow>
         <IconNav />
+        {/* TODO: Add conditions to show/enable this button once valid website/recipe detection is implemented. */}
         {!isRequiresSync ? (
           <ClipRecipeButton
             onClick={() => {

--- a/src/popup/components/App/index.tsx
+++ b/src/popup/components/App/index.tsx
@@ -1,7 +1,9 @@
+import { sendMessageToBackground } from "~/chrome-helpers";
 import config from "~/config";
 import useGetMe from "~/hooks/useGetUserId";
 import IconNav from "~/popup/components/IconNav";
 import LinkPrimaryButton from "~/ui-shared/components/LinkPrimaryButton";
+import PrimaryButton from "~/ui-shared/components/PrimaryButton";
 import { AppContainer, Card, Text, TopRow } from "./styled";
 
 const App = () => {
@@ -11,6 +13,16 @@ const App = () => {
     <AppContainer>
       <TopRow>
         <IconNav />
+        <PrimaryButton
+          onClick={() => {
+            sendMessageToBackground({
+              sender: "popup",
+              type: "SEND_RECIPE_DATA",
+            });
+          }}
+        >
+          Test
+        </PrimaryButton>
       </TopRow>
       {isPending ? null : userId === undefined ? (
         <Card>

--- a/src/popup/components/App/styled.ts
+++ b/src/popup/components/App/styled.ts
@@ -1,4 +1,5 @@
 import styled, { css } from "styled-components";
+import PrimaryButton from "~/ui-shared/components/PrimaryButton";
 
 export const AppContainer = styled.div`
   padding: 8px;
@@ -9,6 +10,10 @@ export const TopRow = styled.div`
   align-items: center;
   justify-content: space-between;
   margin-bottom: 16px;
+`;
+
+export const ClipRecipeButton = styled(PrimaryButton)`
+  margin-left: 32px;
 `;
 
 export const Card = styled.div(

--- a/src/service-worker/index.ts
+++ b/src/service-worker/index.ts
@@ -1,8 +1,59 @@
+import { createEmptyTab, setTabUrl } from "~/chrome-helpers";
 import config from "~/config";
 import { receivableServiceWorkerMessageDecoder } from "~/messages/decoders";
+import { Message } from "~/messages/types";
 import { setUserId } from "~/storage";
 
 const WEB_APP_URL = new URL(config.WEB_APP.ORIGIN);
+
+chrome.runtime.onMessage.addListener(async (rawMessage) => {
+  try {
+    const message = receivableServiceWorkerMessageDecoder.verify(rawMessage);
+
+    switch (message.type) {
+      case "SEND_RECIPE_DATA": {
+        const tab = await createEmptyTab();
+
+        const newTabListener = (
+          newTabRawMessage: unknown,
+          newTabSender: chrome.runtime.MessageSender,
+          sendResponse: (message: Message) => void,
+        ) => {
+          const message =
+            receivableServiceWorkerMessageDecoder.value(newTabRawMessage);
+
+          if (
+            message !== undefined &&
+            message.type === "RECIPE_IMPORTER_READY" &&
+            tab.id !== undefined &&
+            newTabSender.tab?.id === tab.id
+          ) {
+            sendResponse({
+              type: "RECIPE_DATA",
+              sender: "service-worker",
+            });
+
+            chrome.runtime.onMessageExternal.removeListener(newTabListener);
+          }
+        };
+
+        if (tab.id) {
+          chrome.runtime.onMessageExternal.addListener(newTabListener);
+
+          setTabUrl(
+            tab.id,
+            `${config.WEB_APP.ORIGIN}${config.WEB_APP.IMPORT_RECIPE_PATH}`,
+          );
+        }
+
+        break;
+      }
+    }
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error(error);
+  }
+});
 
 chrome.runtime.onMessageExternal.addListener(
   (rawMessage, sender, sendResponse) => {

--- a/src/service-worker/index.ts
+++ b/src/service-worker/index.ts
@@ -1,6 +1,9 @@
 import { createEmptyTab, setTabUrl } from "~/chrome-helpers";
 import config from "~/config";
-import { receivableServiceWorkerMessageDecoder } from "~/messages/decoders";
+import {
+  receivableServiceWorkerMessageDecoder,
+  recipeImporterReadyMessageDecoder,
+} from "~/messages/decoders";
 import { Message } from "~/messages/types";
 import { setUserId } from "~/storage";
 
@@ -20,11 +23,10 @@ chrome.runtime.onMessage.addListener(async (rawMessage) => {
           sendResponse: (message: Message) => void,
         ) => {
           const message =
-            receivableServiceWorkerMessageDecoder.value(newTabRawMessage);
+            recipeImporterReadyMessageDecoder.value(newTabRawMessage);
 
           if (
             message !== undefined &&
-            message.type === "RECIPE_IMPORTER_READY" &&
             tab.id !== undefined &&
             newTabSender.tab?.id === tab.id
           ) {

--- a/src/service-worker/index.ts
+++ b/src/service-worker/index.ts
@@ -42,7 +42,7 @@ chrome.runtime.onMessage.addListener(async (rawMessage) => {
 
           setTabUrl(
             tab.id,
-            `${config.WEB_APP.ORIGIN}${config.WEB_APP.IMPORT_RECIPE_PATH}`,
+            `${config.WEB_APP.ORIGIN}${config.WEB_APP.IMPORT_RECIPE_PATH}?enabled=true`,
           );
         }
 


### PR DESCRIPTION
Adds a basic flow that creates a new tab, loads the "Import Recipe" page in the web app, waits for the ready event, and replies with a simple message. Future PRs will implement sending actual recipe data.