### PR TITLE
chore: Add popup states for supported vs. unsupported websites

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -8,6 +8,10 @@ type Config = {
     VERSION_LINK_PARAM: string;
     WEBSITE_LINK_PARAM: string;
   };
+  REQUEST_FORM: {
+    URL: string;
+    WEBSITE_LINK_PARAM: string;
+  };
   VERSION: string;
   WEB_APP: {
     BROWSER_EXTENSION_PATH: string;
@@ -22,6 +26,10 @@ const configDecoder: Decoder<Config> = exact({
   REPORT_PROBLEM_FORM: exact({
     URL: string,
     VERSION_LINK_PARAM: string,
+    WEBSITE_LINK_PARAM: string,
+  }),
+  REQUEST_FORM: exact({
+    URL: string,
     WEBSITE_LINK_PARAM: string,
   }),
   VERSION: string,
@@ -41,6 +49,10 @@ const config = {
     URL: "https://docs.google.com/forms/d/e/1FAIpQLSeV1bF-mkxoBibHnxKk4AjeVLI8fUjLLRj08Z9nW7vch1qnPg/viewform",
     VERSION_LINK_PARAM: "entry.307864289",
     WEBSITE_LINK_PARAM: "entry.1161392725",
+  },
+  REQUEST_FORM: {
+    URL: "https://docs.google.com/forms/d/e/1FAIpQLSfxOzZQMDKmz8uCvlUskaiZdH6JO9nhc3eWNo59YSgtOqlTHw/viewform",
+    WEBSITE_LINK_PARAM: "entry.895703910",
   },
   VERSION: packageJson.version,
   WEB_APP: {

--- a/src/popup/components/App/index.tsx
+++ b/src/popup/components/App/index.tsx
@@ -34,19 +34,20 @@ const App = () => {
     );
   }
 
-  // TODO: Add conditions to show/enable the clip recipe button once valid website/recipe detection is implemented.
   return (
     <AppContainer>
       <TopRow>
         <IconNav />
-        {!isRequiresSync ? (
+        {!isRequiresSync && isSupported ? (
           <ClipRecipeButton
+            disabled={!isRecipeOnPage}
             onClick={() => {
               sendMessageToBackground({
                 sender: "popup",
                 type: "SEND_RECIPE_DATA",
               });
             }}
+            accessibleWhenDisabled
           >
             Clip recipe
           </ClipRecipeButton>

--- a/src/popup/components/App/index.tsx
+++ b/src/popup/components/App/index.tsx
@@ -1,14 +1,38 @@
 import { sendMessageToBackground } from "~/chrome-helpers";
 import config from "~/config";
+import useGetCurrentTab from "~/hooks/useGetCurrentTab";
 import useGetMe from "~/hooks/useGetUserId";
 import IconNav from "~/popup/components/IconNav";
-import LinkPrimaryButton from "~/ui-shared/components/LinkPrimaryButton";
-import { AppContainer, Card, ClipRecipeButton, Text, TopRow } from "./styled";
+import isRecipePage from "~/utils/isRecipePage";
+import isSupportedWebsite from "~/utils/isSupportedWebsite";
+import {
+  ActionButton,
+  AppContainer,
+  Card,
+  ClipRecipeButton,
+  PrimaryActionButton,
+  Text,
+  TopRow,
+} from "./styled";
 
 const App = () => {
   const { data: userId, isPending } = useGetMe();
+  const { data: currentTab } = useGetCurrentTab();
 
   const isRequiresSync = userId === undefined;
+
+  const isSupported = currentTab?.url
+    ? isSupportedWebsite(currentTab.url)
+    : false;
+  const isRecipeOnPage = currentTab?.url ? isRecipePage(currentTab.url) : false;
+
+  const requestFormUrl = new URL(config.REQUEST_FORM.URL);
+  if (currentTab?.url) {
+    requestFormUrl.searchParams.set(
+      config.REQUEST_FORM.WEBSITE_LINK_PARAM,
+      currentTab.url,
+    );
+  }
 
   // TODO: Add conditions to show/enable the clip recipe button once valid website/recipe detection is implemented.
   return (
@@ -33,14 +57,30 @@ const App = () => {
           <Text>
             Finish setting up this extension by syncing with the web app.
           </Text>
-          <LinkPrimaryButton
+          <PrimaryActionButton
             href={`${config.WEB_APP.ORIGIN}${config.WEB_APP.BROWSER_EXTENSION_PATH}`}
           >
             Launch Tiny Recipe Box in a new tab
-          </LinkPrimaryButton>
+          </PrimaryActionButton>
+        </Card>
+      ) : isRecipeOnPage ? (
+        <Card>
+          <Text>Recipe found.</Text>
+        </Card>
+      ) : isSupported ? (
+        <Card>
+          <Text>To clip a recipe, make sure you’re on a recipe page.</Text>
         </Card>
       ) : (
-        <div>Display app</div>
+        <Card>
+          <Text>
+            Sorry! It looks like we don’t support clipping recipes from this
+            site.
+          </Text>
+          <ActionButton href={requestFormUrl.toString()}>
+            Request support for this site
+          </ActionButton>
+        </Card>
       )}
     </AppContainer>
   );

--- a/src/popup/components/App/styled.ts
+++ b/src/popup/components/App/styled.ts
@@ -1,4 +1,6 @@
 import styled, { css } from "styled-components";
+import LinkButton from "~/popup/components/LinkButton";
+import LinkPrimaryButton from "~/ui-shared/components/LinkPrimaryButton";
 import PrimaryButton from "~/ui-shared/components/PrimaryButton";
 
 export const AppContainer = styled.div`
@@ -26,5 +28,12 @@ export const Card = styled.div(
 
 export const Text = styled.div`
   line-height: 1.25em;
-  margin-bottom: 12px;
+`;
+
+export const PrimaryActionButton = styled(LinkPrimaryButton)`
+  margin-top: 12px;
+`;
+
+export const ActionButton = styled(LinkButton)`
+  margin-top: 12px;
 `;

--- a/src/ui-shared/components/Button.tsx
+++ b/src/ui-shared/components/Button.tsx
@@ -6,6 +6,7 @@ const Button = styled(AriakitButton)(
     --button-background-color: ${theme.colors.lightGray};
     --button-text-color: ${theme.colors.nearBlack};
     --button-hover-background-color: ${theme.colors.gray};
+    --button-disabled-background-color: ${theme.colors.lightGray};
     display: block;
     width: 100%;
     background: var(--button-background-color);
@@ -20,6 +21,11 @@ const Button = styled(AriakitButton)(
 
     &:hover {
       background: var(--button-hover-background-color);
+    }
+
+    &[aria-disabled="true"] {
+      background: var(--button-disabled-background-color);
+      cursor: not-allowed;
     }
 
     &:focus-visible {

--- a/src/ui-shared/components/PrimaryButton.tsx
+++ b/src/ui-shared/components/PrimaryButton.tsx
@@ -6,6 +6,7 @@ const PrimaryButton = styled(Button)(
     --button-background-color: ${theme.colors.purple};
     --button-text-color: ${theme.colors.white};
     --button-hover-background-color: ${theme.colors.darkPurple};
+    --button-disabled-background-color: ${theme.colors.lightPurple};
   `,
 );
 

--- a/src/ui-shared/theme.ts
+++ b/src/ui-shared/theme.ts
@@ -5,6 +5,7 @@ const theme = {
     lightGray: "#f8f9fa",
     gray: "#e1e5ea",
     darkGray: "#616161",
+    lightPurple: "#9f7fd9",
     purple: "#4100b3",
     darkPurple: "#33008c",
   },

--- a/src/utils/isRecipePage.ts
+++ b/src/utils/isRecipePage.ts
@@ -1,0 +1,21 @@
+import { SUPPORTED_HOSTNAMES_DATA } from "~/constants";
+
+const isRecipePage = (url: string) => {
+  try {
+    const { hostname, pathname } = new URL(url);
+
+    const data = SUPPORTED_HOSTNAMES_DATA[hostname];
+
+    if (data === undefined) {
+      return false;
+    }
+
+    const { RECIPE_PAGE_PATHNAME_REGEX } = data;
+
+    return RECIPE_PAGE_PATHNAME_REGEX.test(pathname);
+  } catch (error) {
+    return false;
+  }
+};
+
+export default isRecipePage;

--- a/src/utils/isSupportedWebsite.ts
+++ b/src/utils/isSupportedWebsite.ts
@@ -1,0 +1,16 @@
+import { SUPPORTED_HOSTNAMES_DATA } from "~/constants";
+
+const isSupportedWebsite = (url: string) => {
+  try {
+    const { hostname } = new URL(url);
+
+    return Object.prototype.hasOwnProperty.call(
+      SUPPORTED_HOSTNAMES_DATA,
+      hostname,
+    );
+  } catch (error) {
+    return false;
+  }
+};
+
+export default isSupportedWebsite;


### PR DESCRIPTION
Adds states to the popup UI for when a website is not supported, is supported but not on a recipe page, and is a recipe page.