### PR TITLE
chore: Update extension icon to reflect status of current tab

### DIFF
--- a/src/chrome-helpers.ts
+++ b/src/chrome-helpers.ts
@@ -1,9 +1,14 @@
 import { Message } from "~/messages/types";
 
-export const getCurrentTab = async () => {
+export const getTab = async (tabId: number) => chrome.tabs.get(tabId);
+
+export const getCurrentTab = async ({
+  focused,
+}: { focused?: boolean } = {}) => {
   const [currentTab] = await chrome.tabs.query({
     active: true,
     currentWindow: true,
+    lastFocusedWindow: focused,
   });
 
   return currentTab;
@@ -22,6 +27,16 @@ export const sendMessageToServiceWorker = (message: Message) =>
 
 export const sendMessageToTab = (tabId: number, message: Message) =>
   chrome.tabs.sendMessage(tabId, message);
+
+export const setExtensionIcon = (
+  tabId: number,
+  icon: "active-icon" | "inactive-icon",
+) => {
+  chrome.action.setIcon({
+    path: `/images/${icon}.png`,
+    tabId,
+  });
+};
 
 export const getLocalStorage = async (key: string) => {
   const data = await chrome.storage.local.get(key);

--- a/src/service-worker/index.ts
+++ b/src/service-worker/index.ts
@@ -131,3 +131,17 @@ chrome.windows.onFocusChanged.addListener(async (windowId) => {
     updateExtensionIcon(tab);
   }
 });
+
+const setIconsOnStartup = async () => {
+  const tabs = await chrome.tabs.query({
+    active: true,
+  });
+
+  tabs.forEach((tab) => {
+    updateExtensionIcon(tab);
+  });
+};
+
+chrome.runtime.onInstalled.addListener(setIconsOnStartup);
+
+chrome.runtime.onStartup.addListener(setIconsOnStartup);

--- a/src/service-worker/index.ts
+++ b/src/service-worker/index.ts
@@ -115,7 +115,6 @@ chrome.tabs.onCreated.addListener((tab) => {
 
 chrome.tabs.onActivated.addListener(async (activeInfo) => {
   const tab = await getTab(activeInfo.tabId);
-
   updateExtensionIcon(tab);
 });
 


### PR DESCRIPTION
Adds functionality to update the extension icon for various state changes with the extension, tabs, and windows:
* When a new tab is created
* When a tab becomes active
* When a window becomes focused
* When the browser starts up
* When the extension is installed (or enabled after being disabled)

The icon will be set to a color version if the active tab in the window is a valid recipe page. Otherwise, it will be grayscale.