### PR TITLE
chore: Handle nonexistent tab when setting extension icon

### DIFF
--- a/src/chrome-helpers.ts
+++ b/src/chrome-helpers.ts
@@ -1,6 +1,6 @@
 import { Message } from "~/messages/types";
 
-const NO_TAB_ERROR_REGEX = /No tab with id:/;
+const NO_TAB_ERROR_REGEX = /^No tab with id:/;
 
 export const getTab = async (tabId: number) => chrome.tabs.get(tabId);
 


### PR DESCRIPTION
I was seeing an `Unchecked runtime.lastError: No tab with id: x` error pop up in the extension error logs. After debugging, it seemed to only occur during the call to `chrome.action.setIcon`. This PR adds logic to suppress the expected error if it matches, otherwise log the error.