### PR TITLE
chore: Use type keyword for imports

### DIFF
--- a/src/chrome-helpers.ts
+++ b/src/chrome-helpers.ts
@@ -1,5 +1,5 @@
 import config from "~/config";
-import { Message } from "~/messages/types";
+import type { Message } from "~/messages/types";
 
 const ACTIVE_TAB_QUERY_PARAM_KEY = "active-tab-id";
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,11 +1,11 @@
 /* eslint-disable no-restricted-imports */
 import {
-  Decoder,
   exact,
   nonEmptyString,
   nullable,
   oneOf,
   string,
+  type Decoder,
 } from "decoders";
 import packageJson from "../package.json";
 

--- a/src/content-scripts/recipe-scraper/index.ts
+++ b/src/content-scripts/recipe-scraper/index.ts
@@ -2,7 +2,7 @@ import { sendMessageToServiceWorker } from "~/chrome-helpers";
 import instantiateScraper from "~/content-scripts/recipe-scraper/utils/instantiateScraper";
 import { ImpossibleStateError } from "~/errors";
 import { receivableRecipeScraperMessageDecoder } from "~/messages/decoders";
-import { SendResponseFn } from "~/messages/types";
+import type { SendResponseFn } from "~/messages/types";
 import isRecipePage from "~/utils/isRecipePage";
 import isSupportedWebsite from "~/utils/isSupportedWebsite";
 

--- a/src/content-scripts/recipe-scraper/scrapers/cooking.nytimes.com.ts
+++ b/src/content-scripts/recipe-scraper/scrapers/cooking.nytimes.com.ts
@@ -1,4 +1,4 @@
-import { BaseScraper, Executor, Scraper } from ".";
+import { BaseScraper, type Executor, type Scraper } from ".";
 
 interface Props {
   customExecuteInPageScope?: Executor;

--- a/src/content-scripts/recipe-scraper/utils/instantiateScraper.ts
+++ b/src/content-scripts/recipe-scraper/utils/instantiateScraper.ts
@@ -1,4 +1,4 @@
-import { Scraper } from "~/content-scripts/recipe-scraper/scrapers";
+import type { Scraper } from "~/content-scripts/recipe-scraper/scrapers";
 import TimesScraper from "~/content-scripts/recipe-scraper/scrapers/cooking.nytimes.com";
 
 const instantiateScraper = (url: string): Scraper | undefined => {

--- a/src/messages/decoders.ts
+++ b/src/messages/decoders.ts
@@ -1,5 +1,4 @@
 import {
-  Decoder,
   constant,
   either,
   exact,
@@ -7,8 +6,9 @@ import {
   oneOf,
   string,
   uuidv4,
+  type Decoder,
 } from "decoders";
-import {
+import type {
   ErrorMessage,
   ExtractRecipeMessage,
   OpenUrlForE2ETestMessage,

--- a/src/options/components/HorizontalSeparator.tsx
+++ b/src/options/components/HorizontalSeparator.tsx
@@ -1,4 +1,4 @@
-import { ComponentPropsWithoutRef } from "react";
+import type { ComponentPropsWithoutRef } from "react";
 import { useSeparator } from "react-aria";
 import styled, { css } from "styled-components";
 

--- a/src/popup/components/LinkButton.tsx
+++ b/src/popup/components/LinkButton.tsx
@@ -1,4 +1,4 @@
-import { ComponentPropsWithoutRef } from "react";
+import type { ComponentPropsWithoutRef } from "react";
 import Button from "~/ui-shared/components/Button";
 
 interface Props extends ComponentPropsWithoutRef<typeof Button> {

--- a/src/service-worker/index.ts
+++ b/src/service-worker/index.ts
@@ -10,7 +10,7 @@ import {
   receivableServiceWorkerMessageDecoder,
   recipeImporterReadyMessageDecoder,
 } from "~/messages/decoders";
-import { SendResponseFn } from "~/messages/types";
+import type { SendResponseFn } from "~/messages/types";
 import exceptionLogger from "~/service-worker/exception-logger";
 import { setUserId } from "~/storage";
 import assertIsError from "~/utils/assertIsError";

--- a/src/styled.d.ts
+++ b/src/styled.d.ts
@@ -1,5 +1,5 @@
 import "styled-components";
-import theme from "~/ui-shared/theme";
+import type theme from "~/ui-shared/theme";
 
 type CustomTheme = typeof theme;
 

--- a/src/ui-shared/components/LinkPrimaryButton.tsx
+++ b/src/ui-shared/components/LinkPrimaryButton.tsx
@@ -1,4 +1,4 @@
-import { ComponentPropsWithoutRef } from "react";
+import type { ComponentPropsWithoutRef } from "react";
 import PrimaryButton from "~/ui-shared/components/PrimaryButton";
 
 interface Props extends ComponentPropsWithoutRef<typeof PrimaryButton> {

--- a/src/ui-shared/components/Tooltip/index.tsx
+++ b/src/ui-shared/components/Tooltip/index.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from "react";
+import type { ReactNode } from "react";
 import { OverlayArrow } from "react-aria-components";
 import { StyledTooltip } from "./styled";
 

--- a/src/utils/error-log.ts
+++ b/src/utils/error-log.ts
@@ -1,5 +1,4 @@
 import {
-  Decoder,
   array,
   nonEmptyString,
   number,
@@ -8,6 +7,7 @@ import {
   record,
   string,
   unknown,
+  type Decoder,
 } from "decoders";
 import { getErrorLog as getStoredErrorLog, setErrorLog } from "~/storage";
 


### PR DESCRIPTION
This may reduce bundle size. There's also a [lint rule](https://typescript-eslint.io/rules/consistent-type-imports/) that I intend to enable in the future.